### PR TITLE
Remove unnecesary autoware_build_flags from vector_map_msgs

### DIFF
--- a/vector_map_msgs/CMakeLists.txt
+++ b/vector_map_msgs/CMakeLists.txt
@@ -2,13 +2,10 @@ cmake_minimum_required(VERSION 2.8.3)
 project(vector_map_msgs)
 
 
-find_package(autoware_build_flags REQUIRED)
 find_package(catkin REQUIRED COMPONENTS
   std_msgs
   message_generation
 )
-
-set(CMAKE_CXX_FLAGS "-O2 -Wall ${CMAKE_CXX_FLAGS}")
 
 add_message_files(
   FILES

--- a/vector_map_msgs/package.xml
+++ b/vector_map_msgs/package.xml
@@ -6,7 +6,6 @@
   <maintainer email="syouji@axe.bz">syouji</maintainer>
   <license>Apache 2</license>
   <buildtool_depend>catkin</buildtool_depend>
-  <buildtool_depend>autoware_build_flags</buildtool_depend>
 
   <build_depend>std_msgs</build_depend>
   <build_depend>message_generation</build_depend>


### PR DESCRIPTION
### Fix applied
Removes unnecessary dependency `autoware_build_flags` from `vector_map_msgs` package as described in #5 


